### PR TITLE
refactor: improve table deletion logic to handle edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bq-editor",
   "description": "BQ Remirror Editor",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "keywords": [
     "prosemirror",
     "react",


### PR DESCRIPTION
- Replace isEntireTableSelected with runDeleteOrRemoveTable helper that cleans up broken tables
- Add forceDeleteTable to directly remove table nodes from document
- Use requestAnimationFrame to ensure state settles before checking for broken tables
- Detect and remove tables with no rows, only controller row, or only controller cells
- Simplify delete row/column handlers to use new cleanup logic
- Remove redundant entire table selection checks